### PR TITLE
fix: change method of grabbing state name

### DIFF
--- a/features/vaccineData.js
+++ b/features/vaccineData.js
@@ -10,7 +10,7 @@ module.exports = function (app) {
 
 async function vaccineData({ message, client }) {
   //Place state abbriviation into own variable
-  const [, stateAbv] = message.text.split(" ");
+  const stateAbv = message.text.slice(-2);
 
   //Use input state to retrieve data
   const stateVaccineData = await vaccine.getUsDataByState(stateAbv);

--- a/features/vaccineData.js
+++ b/features/vaccineData.js
@@ -1,0 +1,26 @@
+const vaccine = require("../repositories/vaccineOps.js")
+
+//Should Take in vaccine keyword and two letter state
+module.exports = function (app) {
+
+   //Regular Expression search (vaccine + State Abbreviation)
+   let vaccineSearch =  /vaccine (AL|AK|AZ|AR|CA|CO|CT|DE|FL|GA|HI|ID|IL|IN|IA|KS|KY|LA|ME|D|MA|MI|MN|MS|MO|MT|NE|NV|NH|NJ|NM|NY|NC|ND|OH|OK|OR|PA|RI|SC|SD|TN|TX|UT|VT|VA|WA|WV|WI|WY)/;
+  app.message(vaccineSearch, vaccineData);
+
+};
+
+async function vaccineData({ message, client }) {
+
+  //Cut out State Abbriviation into array 
+  stateAbbriv = message.text;
+  const stateAbv = message.text.split(" ", 2);
+
+  //Use input state to retrieve data
+  const vaccinedata = await vaccine.getUsData(stateAbv[1]);
+
+  await client.chat.postEphemeral({
+    channel: message.channel,
+    user: message.user,
+    text: ("Percentage Vaccinated in " + stateAbv[1] + ": " + vaccinedata[0].series_complete_pop_pct + "%"),
+  });
+}

--- a/features/vaccineData.js
+++ b/features/vaccineData.js
@@ -10,7 +10,6 @@ module.exports = function (app) {
 
 async function vaccineData({ message, client }) {
   //Cut out State Abbriviation into array
-  stateAbbriv = message.text;
   const stateAbv = message.text.split(" ", 2);
 
   //Use input state to retrieve data

--- a/features/vaccineData.js
+++ b/features/vaccineData.js
@@ -1,17 +1,15 @@
-const vaccine = require("../repositories/vaccineOps.js")
+const vaccine = require("../repositories/vaccineOps.js");
 
 //Should Take in vaccine keyword and two letter state
 module.exports = function (app) {
-
-   //Regular Expression search (vaccine + State Abbreviation)
-   let vaccineSearch =  /vaccine (AL|AK|AZ|AR|CA|CO|CT|DE|FL|GA|HI|ID|IL|IN|IA|KS|KY|LA|ME|D|MA|MI|MN|MS|MO|MT|NE|NV|NH|NJ|NM|NY|NC|ND|OH|OK|OR|PA|RI|SC|SD|TN|TX|UT|VT|VA|WA|WV|WI|WY)/;
+  //Regular Expression search (vaccine + State Abbreviation)
+  let vaccineSearch =
+    /vaccine (AL|AK|AZ|AR|CA|CO|CT|DE|FL|GA|HI|ID|IL|IN|IA|KS|KY|LA|ME|D|MA|MI|MN|MS|MO|MT|NE|NV|NH|NJ|NM|NY|NC|ND|OH|OK|OR|PA|RI|SC|SD|TN|TX|UT|VT|VA|WA|WV|WI|WY)/;
   app.message(vaccineSearch, vaccineData);
-
 };
 
 async function vaccineData({ message, client }) {
-
-  //Cut out State Abbriviation into array 
+  //Cut out State Abbriviation into array
   stateAbbriv = message.text;
   const stateAbv = message.text.split(" ", 2);
 
@@ -21,6 +19,11 @@ async function vaccineData({ message, client }) {
   await client.chat.postEphemeral({
     channel: message.channel,
     user: message.user,
-    text: ("Percentage Vaccinated in " + stateAbv[1] + ": " + vaccinedata[0].series_complete_pop_pct + "%"),
+    text:
+      "Percentage Vaccinated in " +
+      stateAbv[1] +
+      ": " +
+      vaccinedata[0].series_complete_pop_pct +
+      "%",
   });
 }

--- a/features/vaccineData.js
+++ b/features/vaccineData.js
@@ -1,28 +1,23 @@
 const vaccine = require("../repositories/vaccineOps.js");
+const vaccineSearch =
+  /vaccine (AL|AK|AZ|AR|CA|CO|CT|DE|FL|GA|HI|ID|IL|IN|IA|KS|KY|LA|ME|D|MA|MI|MN|MS|MO|MT|NE|NV|NH|NJ|NM|NY|NC|ND|OH|OK|OR|PA|RI|SC|SD|TN|TX|UT|VT|VA|WA|WV|WI|WY)/;
 
 //Should Take in vaccine keyword and two letter state
 module.exports = function (app) {
   //Regular Expression search (vaccine + State Abbreviation)
-  let vaccineSearch =
-    /vaccine (AL|AK|AZ|AR|CA|CO|CT|DE|FL|GA|HI|ID|IL|IN|IA|KS|KY|LA|ME|D|MA|MI|MN|MS|MO|MT|NE|NV|NH|NJ|NM|NY|NC|ND|OH|OK|OR|PA|RI|SC|SD|TN|TX|UT|VT|VA|WA|WV|WI|WY)/;
   app.message(vaccineSearch, vaccineData);
 };
 
 async function vaccineData({ message, client }) {
-  //Cut out State Abbriviation into array
-  const stateAbv = message.text.split(" ", 2);
+  //Place state abbriviation into own variable
+  const [, stateAbv] = message.text.split(" ");
 
   //Use input state to retrieve data
-  const vaccinedata = await vaccine.getUsData(stateAbv[1]);
+  const stateVaccineData = await vaccine.getUsDataByState(stateAbv);
 
   await client.chat.postEphemeral({
     channel: message.channel,
     user: message.user,
-    text:
-      "Percentage Vaccinated in " +
-      stateAbv[1] +
-      ": " +
-      vaccinedata[0].series_complete_pop_pct +
-      "%",
+    text: `Percentage Vaccinated in ${stateAbv}: ${stateVaccineData[0].series_complete_pop_pct}%`,
   });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libotrio",
-  "version": "2.0.2",
+  "version": "2.1.1",
   "description": "Liatrio's new and improved Libotrio",
   "main": "index.js",
   "scripts": {

--- a/repositories/vaccineOps.js
+++ b/repositories/vaccineOps.js
@@ -1,14 +1,20 @@
-const axios = require('axios');
+const axios = require("axios");
 
 module.exports = {
-    getUsData: async (state) => {
+  getUsData: async (state) => {
+    //Get current data for most recent date
+    var yesterday = new Date(new Date().valueOf() - 1000 * 60 * 60 * 24)
+      .toISOString()
+      .slice(0, 10);
+    let apicall =
+      "https://data.cdc.gov/resource/unsk-b7fc.json?location=" +
+      state +
+      "&date=" +
+      yesterday +
+      "T00:00:00.000";
 
-        //Get current data for most recent date
-        var yesterday = new Date((new Date()).valueOf() - 1000*60*60*24).toISOString().slice(0, 10);
-        let apicall = 'https://data.cdc.gov/resource/unsk-b7fc.json?location=' + state + '&date=' + yesterday + 'T00:00:00.000';
-        
-        //Use axios library for https request	
-	const response = await axios(apicall);
-	return response.data;
-    	}
-}
+    //Use axios library for https request
+    const response = await axios(apicall);
+    return response.data;
+  },
+};

--- a/repositories/vaccineOps.js
+++ b/repositories/vaccineOps.js
@@ -1,0 +1,14 @@
+const axios = require('axios');
+
+module.exports = {
+    getUsData: async (state) => {
+
+        //Get current data for most recent date
+        var yesterday = new Date((new Date()).valueOf() - 1000*60*60*24).toISOString().slice(0, 10);
+        let apicall = 'https://data.cdc.gov/resource/unsk-b7fc.json?location=' + state + '&date=' + yesterday + 'T00:00:00.000';
+        
+        //Use axios library for https request	
+	const response = await axios(apicall);
+	return response.data;
+    	}
+}

--- a/repositories/vaccineOps.js
+++ b/repositories/vaccineOps.js
@@ -1,20 +1,15 @@
 const axios = require("axios");
 
 module.exports = {
-  getUsData: async (state) => {
+  getUsDataByState: async (state) => {
     //Get current data for most recent date
-    var yesterday = new Date(new Date().valueOf() - 1000 * 60 * 60 * 24)
+    const yesterday = new Date(new Date().valueOf() - 1000 * 60 * 60 * 24)
       .toISOString()
       .slice(0, 10);
-    let apicall =
-      "https://data.cdc.gov/resource/unsk-b7fc.json?location=" +
-      state +
-      "&date=" +
-      yesterday +
-      "T00:00:00.000";
+    const url = `https://data.cdc.gov/resource/unsk-b7fc.json?location=${state}&date=${yesterday}T00:00:00.000`;
 
     //Use axios library for https request
-    const response = await axios(apicall);
+    const response = await axios(url);
     return response.data;
   },
 };


### PR DESCRIPTION
Change method of grabbing state name from slack message to support function calls that include the slackbot command. 